### PR TITLE
Enable Proxy Authentication by setting credentials in the proxy URI

### DIFF
--- a/src/main/java/com/sportalliance/graylog/plugins/slacknotification/SlackClient.java
+++ b/src/main/java/com/sportalliance/graylog/plugins/slacknotification/SlackClient.java
@@ -49,7 +49,7 @@ public class SlackClient {
 			if (!StringUtils.isEmpty(proxyURL)) {
 				final URI proxyUri = new URI(proxyURL);
 				if (!StringUtils.isEmpty(proxyUri.getUserInfo())) {
-					uthenticator.setDefault(new ProxyAuthenticator(proxyUri.getUserInfo()));
+					Authenticator.setDefault(new ProxyAuthenticator(proxyUri.getUserInfo()));
 				}
 				InetSocketAddress sockAddress = new InetSocketAddress(proxyUri.getHost(), proxyUri.getPort());
 				final Proxy proxy = new Proxy(Proxy.Type.HTTP, sockAddress);

--- a/src/main/java/com/sportalliance/graylog/plugins/slacknotification/SlackClient.java
+++ b/src/main/java/com/sportalliance/graylog/plugins/slacknotification/SlackClient.java
@@ -4,9 +4,12 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
+import java.lang.String;
+import java.net.Authenticator;
 import java.net.HttpURLConnection;
 import java.net.InetSocketAddress;
 import java.net.MalformedURLException;
+import java.net.PasswordAuthentication;
 import java.net.Proxy;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -45,6 +48,9 @@ public class SlackClient {
 		try {
 			if (!StringUtils.isEmpty(proxyURL)) {
 				final URI proxyUri = new URI(proxyURL);
+				if (!StringUtils.isEmpty(proxyUri.getUserInfo())) {
+					uthenticator.setDefault(new ProxyAuthenticator(proxyUri.getUserInfo()));
+				}
 				InetSocketAddress sockAddress = new InetSocketAddress(proxyUri.getHost(), proxyUri.getPort());
 				final Proxy proxy = new Proxy(Proxy.Type.HTTP, sockAddress);
 				conn = (HttpURLConnection) url.openConnection(proxy);
@@ -104,5 +110,24 @@ public class SlackClient {
 		}
 
 	}
+
+
+	public class ProxyAuthenticator extends Authenticator {
+		String ProxyUserInfo;
+		String ProxyUserName;
+		String ProxyUserPassword;
+
+		public ProxyAuthenticator(String ProxyUserInfo) {
+			String[] parts = ProxyUserInfo.split(":");
+			ProxyUserName = parts[0];
+			ProxyUserPassword = parts[1];
+		}
+
+		public PasswordAuthentication getPasswordAuthentication(){
+			return new PasswordAuthentication(ProxyUserName, ProxyUserPassword.toCharArray());
+		}
+
+	}
+
 
 }

--- a/src/web/form/SlackNotificationForm.jsx
+++ b/src/web/form/SlackNotificationForm.jsx
@@ -152,7 +152,7 @@ class SlackNotificationForm extends React.Component {
                label="Proxy (optional)"
                type="text"
                bsStyle={validation.errors.proxy ? 'error' : null}
-               help={lodash.get(validation, 'errors.proxy[0]', 'Please insert the proxy information in the follwoing format: <ProxyAddress>:<Port>')}
+               help={lodash.get(validation, 'errors.proxy[0]', 'When a web proxy is required please insert the proxy information in the following format: http://username:password@proxy.example.com:8080 where the username:password @ credentials may be omitted when the proxy does not require authentication')}
                value={config.proxy || ''}
                onChange={this.handleChange} />
       </React.Fragment>


### PR DESCRIPTION
Allow specification of username and password in the Proxy URI  (in the conventional format of `http://username:password@proxy.example.com:8080`)  and when supplied use those credentials for  authentication to the proxy server before posting the web request to the Webhook URL.  