### PR TITLE
Add registration for Jackson subtype to avoid content pack import error

### DIFF
--- a/src/main/java/com/sportalliance/graylog/plugins/slacknotification/SlackNotificationModule.java
+++ b/src/main/java/com/sportalliance/graylog/plugins/slacknotification/SlackNotificationModule.java
@@ -4,6 +4,7 @@ import org.graylog2.plugin.PluginModule;
 
 import com.sportalliance.graylog.plugins.slacknotification.config.SlackEventNotification;
 import com.sportalliance.graylog.plugins.slacknotification.config.SlackEventNotificationConfig;
+import com.sportalliance.graylog.plugins.slacknotification.config.SlackEventNotificationConfigEntity;
 
 /**
  * Extend the PluginModule abstract class here to add you plugin to the system.
@@ -16,5 +17,7 @@ public class SlackNotificationModule extends PluginModule {
 				SlackEventNotificationConfig.class,
 				SlackEventNotification.class,
 				SlackEventNotification.Factory.class);
+		registerJacksonSubtype(SlackEventNotificationConfigEntity.class,
+                    SlackEventNotificationConfigEntity.TYPE_NAME);
 	}
 }


### PR DESCRIPTION
Allows content pack containing the notification to be imported successfully.

Avoids `IllegalArgumentException: Could not resolve type id '<notification-type>' as a subtype of ` error mentioned in https://github.com/Graylog2/graylog2-server/issues/7801

Similar to fix supplied in Graylog core here: 
https://github.com/Graylog2/graylog2-server/pull/13171